### PR TITLE
build: pin craft-parts to keep organize from build

### DIFF
--- a/debcraft/models/package.py
+++ b/debcraft/models/package.py
@@ -45,7 +45,6 @@ class Package(models.CraftBaseModel):
     breaks: list[str] | None = None
     replaces: list[str] | None = None
     conflicts: list[str] | None = None
-    suggests: list[str] | None = None
 
     section: str | None = None
 

--- a/debcraft/models/package.py
+++ b/debcraft/models/package.py
@@ -45,6 +45,7 @@ class Package(models.CraftBaseModel):
     breaks: list[str] | None = None
     replaces: list[str] | None = None
     conflicts: list[str] | None = None
+    suggests: list[str] | None = None
 
     section: str | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ description = "Pack up debs with the Crafting Experience"
 dynamic = ["version"]
 dependencies = [
     "craft-application>=5.4.0",
-    #"craft-parts>=2.31.0",
+    # Pin craft-parts to a version allowing organize from build. Update this to a feature
+    # branch when ready, or to stable releases when all organize from build issues are solved.
     "craft-parts @ git+https://github.com/canonical/craft-parts@5620314d17432d98f22cb62ee40c1180510e19a9",
     "zstandard>=0.25.0",
     "pyelftools>=0.32",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ description = "Pack up debs with the Crafting Experience"
 dynamic = ["version"]
 dependencies = [
     "craft-application>=5.4.0",
-    "craft-parts>=2.31.0",
+    #"craft-parts>=2.31.0",
+    "craft-parts @ git+https://github.com/canonical/craft-parts@5620314d17432d98f22cb62ee40c1180510e19a9",
     "zstandard>=0.25.0",
     "pyelftools>=0.32",
 ]


### PR DESCRIPTION
Keep organize from build enabled in Debcraft builds while an organize
regression issue is investigated in Craft Parts.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
