### PR TITLE
fix: add suggests to package and control models

### DIFF
--- a/debcraft/helpers/gencontrol.py
+++ b/debcraft/helpers/gencontrol.py
@@ -73,7 +73,6 @@ class Gencontrol(Helper):
         shlibdeps = _read_shlibdeps(state_dir)
         depends = _filter_dependencies(shlibdeps, package.depends)
 
-        # Change to use package data from the project model
         ctl_data = models.DebianBinaryPackageControl(
             package=package_name,
             source=project.name,
@@ -84,6 +83,7 @@ class Gencontrol(Helper):
             installed_size=int(installed_size / 1024),
             depends=depends,
             recommends=package.recommends,
+            suggests=package.suggests,
             provides=package.provides,
             breaks=package.breaks,
             replaces=package.replaces,

--- a/debcraft/models/control.py
+++ b/debcraft/models/control.py
@@ -44,6 +44,7 @@ class DebianBinaryPackageControl(models.CraftBaseModel):
     installed_size: int
     depends: list[str] | None = None
     recommends: list[str] | None = None
+    suggests: list[str] | None = None
     conflicts: list[str] | None = None
     breaks: list[str] | None = None
     replaces: list[str] | None = None

--- a/debcraft/models/package.py
+++ b/debcraft/models/package.py
@@ -41,6 +41,7 @@ class Package(models.CraftBaseModel):
     # https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps
     depends: list[str] | None = None
     recommends: list[str] | None = None
+    suggests: list[str] | None = None
     provides: list[str] | None = None
     breaks: list[str] | None = None
     replaces: list[str] | None = None

--- a/schema/debcraft.json
+++ b/schema/debcraft.json
@@ -103,6 +103,21 @@
           "default": null,
           "title": "Recommends"
         },
+        "suggests": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Suggests"
+        },
         "provides": {
           "anyOf": [
             {

--- a/tests/unit/helpers/test_gencontrol.py
+++ b/tests/unit/helpers/test_gencontrol.py
@@ -35,8 +35,9 @@ def test_run(tmp_path, default_project):
 
     package = default_project.packages["package-1"]
     package.recommends = []
+    package.suggests = ["other-package"]
     package.provides = ["old-package"]
-    package.breaks = ["package-2", "package-3"]
+    package.breaks = ["package-2 (<= 1.2.0)", "package-3"]
     package.replaces = ["package-4"]
     package.conflicts = ["package-5"]
 
@@ -60,8 +61,9 @@ def test_run(tmp_path, default_project):
         Maintainer: Mike Maintainer <someone@example.com>
         Installed-Size: 0
         Depends: libfoo 5 libfoo5 (>= 5.1.2)
+        Suggests: other-package
         Conflicts: package-5
-        Breaks: package-2, package-3
+        Breaks: package-2 (<= 1.2.0), package-3
         Replaces: package-4
         Provides: old-package
         Section: libs


### PR DESCRIPTION
Add support for the Debian Suggests relationship by extending Debcraft’s
package model and ensuring the generated Debian binary control file
includes the Suggests: field when configured.

Fixes #124

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
