### PR TITLE
fix: add multi-arch to package and control models

### DIFF
--- a/debcraft/helpers/gencontrol.py
+++ b/debcraft/helpers/gencontrol.py
@@ -94,6 +94,9 @@ class Gencontrol(Helper):
             uploaders=project.uploaders,
         )
 
+        if package.multi_arch != "no":
+            ctl_data.multi_arch = package.multi_arch
+
         emit.progress(f"Create control file for package {package_name}")
         output_file = control_dir / "control"
 

--- a/debcraft/models/control.py
+++ b/debcraft/models/control.py
@@ -54,3 +54,4 @@ class DebianBinaryPackageControl(models.CraftBaseModel):
     description: str
     original_maintainer: str | None = None
     uploaders: list[str] | None = None
+    multi_arch: str | None = None

--- a/debcraft/models/control.py
+++ b/debcraft/models/control.py
@@ -19,6 +19,8 @@
 from craft_application import models
 from pydantic import ConfigDict
 
+from debcraft.models.package import DebianMultiArch
+
 
 def _field_alias(field_name: str) -> str:
     parts = field_name.replace("_", "-").split("-")
@@ -54,4 +56,4 @@ class DebianBinaryPackageControl(models.CraftBaseModel):
     description: str
     original_maintainer: str | None = None
     uploaders: list[str] | None = None
-    multi_arch: str | None = None
+    multi_arch: DebianMultiArch | None = None

--- a/debcraft/models/package.py
+++ b/debcraft/models/package.py
@@ -21,6 +21,8 @@ import pydantic
 from craft_application import models
 from craft_platforms import DebianArchitecture
 
+DebianMultiArch = Literal["no", "same", "foreign", "allowed"]
+
 
 class Package(models.CraftBaseModel):
     """A single binary package.
@@ -48,7 +50,7 @@ class Package(models.CraftBaseModel):
     conflicts: list[str] | None = None
 
     section: str | None = None
-    multi_arch: Literal["no", "same", "foreign", "allowed"] = "no"
+    multi_arch: DebianMultiArch = "no"
 
     passthrough: dict[str, str] = pydantic.Field(default_factory=dict)
     """Values that are passed directly into the control stanza for this package.

--- a/debcraft/models/package.py
+++ b/debcraft/models/package.py
@@ -48,6 +48,7 @@ class Package(models.CraftBaseModel):
     conflicts: list[str] | None = None
 
     section: str | None = None
+    multi_arch: Literal["no", "same", "foreign", "allowed"] = "no"
 
     passthrough: dict[str, str] = pydantic.Field(default_factory=dict)
     """Values that are passed directly into the control stanza for this package.

--- a/schema/debcraft.json
+++ b/schema/debcraft.json
@@ -190,6 +190,17 @@
           "default": null,
           "title": "Section"
         },
+        "multi-arch": {
+          "default": "no",
+          "enum": [
+            "no",
+            "same",
+            "foreign",
+            "allowed"
+          ],
+          "title": "Multi-Arch",
+          "type": "string"
+        },
         "passthrough": {
           "additionalProperties": {
             "type": "string"

--- a/tests/integration/project/invalid-projects/invalid-multi-arch/debcraft.yaml
+++ b/tests/integration/project/invalid-projects/invalid-multi-arch/debcraft.yaml
@@ -1,0 +1,8 @@
+name: debcraft-multi-arch
+summary: A debcraft project with an invalid multi-arch value.
+maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+version: 0
+
+packages:
+  pkg1:
+    multi-arch: yes

--- a/tests/integration/project/invalid-projects/invalid-multi-arch/error-message.txt
+++ b/tests/integration/project/invalid-projects/invalid-multi-arch/error-message.txt
@@ -1,0 +1,2 @@
+Bad debcraft.yaml content:
+- input should be 'no', 'same', 'foreign' or 'allowed' (in field 'packages.pkg1.multi-arch')

--- a/tests/integration/project/valid-projects/multi-arch/debcraft.yaml
+++ b/tests/integration/project/valid-projects/multi-arch/debcraft.yaml
@@ -1,0 +1,15 @@
+name: debcraft-multi-arch
+maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+version: 0
+
+packages:
+  pkg0:
+    version: 0
+  pkg1:
+    multi-arch: "no" # Don't forget to quote "no"!
+  pkg2:
+    multi-arch: same
+  pkg3:
+    multi-arch: foreign
+  pkg4:
+    multi-arch: allowed

--- a/tests/unit/helpers/test_gencontrol.py
+++ b/tests/unit/helpers/test_gencontrol.py
@@ -75,6 +75,55 @@ def test_run(tmp_path, default_project):
 
 
 @pytest.mark.parametrize(
+    ("multi_arch", "control_value"),
+    [
+        ("no", ""),
+        ("same", "Multi-Arch: same\n"),
+        ("foreign", "Multi-Arch: foreign\n"),
+        ("allowed", "Multi-Arch: allowed\n"),
+    ],
+)
+def test_multi_arch(tmp_path, default_project, multi_arch, control_value):
+    prime_dir = tmp_path / "prime"
+    control_dir = tmp_path / "control"
+    state_dir = tmp_path / "state"
+
+    prime_dir.mkdir()
+    control_dir.mkdir()
+    state_dir.mkdir()
+
+    package = default_project.packages["package-1"]
+    package.multi_arch = multi_arch
+
+    helper = gencontrol.Gencontrol()
+    helper.run(
+        project=default_project,
+        package_name="package-1",
+        arch="arm64",
+        prime_dir=prime_dir,
+        control_dir=control_dir,
+        state_dir=state_dir,
+    )
+
+    content = (control_dir / "control").read_text()
+    assert content == textwrap.dedent(
+        """\
+        Package: package-1
+        Source: fake-project
+        Version: 2.0
+        Architecture: arm64
+        Maintainer: Mike Maintainer <someone@example.com>
+        Installed-Size: 0
+        Section: libs
+        Priority: optional
+        Description: A package
+         Really a package
+        """
+        + control_value
+    )
+
+
+@pytest.mark.parametrize(
     ("deps", "user_deps", "result"),
     [
         pytest.param([], [], [], id="empty"),


### PR DESCRIPTION
Add support for the Debian Multi-Arch field to the Debcraft package
model and the generated Debian binary control file.

Fixes #125

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
