### PR TITLE
feat: install lintian-overrides file

### DIFF
--- a/debcraft/helpers/__init__.py
+++ b/debcraft/helpers/__init__.py
@@ -22,6 +22,7 @@ from .gencontrol import Gencontrol
 from .helpers import HelperGroup
 from .installchangelogs import Installchangelogs
 from .installdocs import Installdocs
+from .lintian import Lintian
 from .makedeb import Makedeb
 from .makeshlibs import Makeshlibs
 from .md5sums import Md5sums
@@ -33,6 +34,7 @@ class InstallHelpers(HelperGroup):
     """Helpers used during build."""
 
     def _register(self) -> None:
+        self._register_helper("lintian", Lintian)
         self._register_helper("installdocs", Installdocs)
         self._register_helper("installchangelogs", Installchangelogs)
         self._register_helper("strip", Strip)

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -123,7 +123,10 @@ def install_package_control(
 
     Read files named ``<package-name>.<name>`` from the ``debcraft/`` or
     ``debian/`` directories in the source package and add them to the
-    control tarball of the corresponding package.
+    control tarball of the corresponding package. A file named ``<name>``
+    is also supported and is treated as applying to ``project.name``.
+    If matching files exist in both directories for the same package,
+    the file from ``debcraft/`` takes precedence over the one from ``debian/``.
 
     :param name: The name used as the file suffix.
     :param project: The project model.

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -62,7 +62,7 @@ class HelperGroup(ABC):
         return helper
 
 
-def install_to_package_data(
+def install_package_data(
     *,
     name: str,
     project: models.Project,
@@ -107,7 +107,7 @@ def install_to_package_data(
         emit.progress(f"Install {name} file: {file_path}")
 
 
-def install_to_package_control(
+def install_package_control(
     *,
     name: str,
     project: models.Project,
@@ -143,7 +143,7 @@ def install_to_package_control(
         if not pfile:
             continue
 
-        dest = partition_dir / "package" / package / "control" / name
+        dest = partition_dir / "package" / package / "debcraft_control" / name
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(pfile, dest)
         dest.chmod(0o644)

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -16,7 +16,13 @@
 
 """Debcraft helpers base."""
 
+import shutil
 from abc import ABC, abstractmethod
+from pathlib import Path
+
+from craft_cli import emit
+
+from debcraft import models
 
 
 class Helper:
@@ -54,3 +60,115 @@ class HelperGroup(ABC):
             self._helper[name] = helper
 
         return helper
+
+
+def install_to_package_data(
+    *,
+    name: str,
+    project: models.Project,
+    dest_dir: Path,
+    build_dir: Path,
+    install_dirs: dict[str, Path],
+) -> None:
+    """Install package-specific files from the debian directory.
+
+    Read files named ``<package-name>.<name>`` from the ``debcraft/`` or
+    ``debian/`` directories in the source  copy them to the specified
+    destination path in the corresponding package, with the suffix
+    removed.
+
+    :param name: The name used as the file suffix.
+    :param project: The project model.
+    :param dest_dir: The destination path in the binary package.
+    :param build_dir: The path to the sources being built.
+    :param install_dirs: The map to the part install directory in
+        each partition.
+    """
+    for debian_dir_name in ("debcraft", "debian"):
+        file_map = _build_file_map(
+            name, project_name=project.name, debian_dir=build_dir / debian_dir_name
+        )
+
+        installed_file = False
+        for partition, install_dir in install_dirs.items():
+            if partition in ("default", "build"):
+                continue
+
+            package = partition.removeprefix("package/")
+            pfile = file_map.get(package)
+            if not pfile:
+                continue
+
+            file_path = Path(dest_dir) / package
+            dest = install_dir / file_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(pfile, dest)
+            dest.chmod(0o644)
+            emit.progress(f"Install {name} file: {file_path}")
+            installed_file = True
+
+        if installed_file:
+            return
+
+
+def install_to_package_control(
+    *,
+    name: str,
+    project: models.Project,
+    build_dir: Path,
+    partition_dir: Path,
+    install_dirs: dict[str, Path],
+) -> None:
+    """Install package-specific files from the debian directory.
+
+    Read files named ``<package-name>.<name>`` from the ``debcraft/`` or
+    ``debian/`` directories in the source package and add them to the
+    control tarball of the corresponding package.
+
+    :param name: The name used as the file suffix.
+    :param project: The project model.
+    :param build_dir: The path to the sources being built.
+    :param partition_dir: The path to the project partitions.
+    :param install_dirs: The map to the part install directory in
+        each partition.
+    """
+    for debian_dir_name in ("debcraft", "debian"):
+        file_map = _build_file_map(
+            name, project_name=project.name, debian_dir=build_dir / debian_dir_name
+        )
+
+        installed_file = False
+        for partition in install_dirs:
+            if partition in ("default", "build"):
+                continue
+
+            package = partition.removeprefix("package/")
+            pfile = file_map.get(package)
+            if not pfile:
+                continue
+
+            dest = partition_dir / "package" / package / name / "control"
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(pfile, dest)
+            dest.chmod(0o644)
+            emit.progress(f"Install {name} to package {package} control file")
+            installed_file = True
+
+        if installed_file:
+            return
+
+
+def _build_file_map(name: str, project_name: str, debian_dir: Path) -> dict[str, Path]:
+    file_map: dict[str, Path] = {}
+
+    default_file = debian_dir / name
+    if default_file.is_file():
+        file_map[project_name] = default_file
+
+    package_files = debian_dir.glob(f"*.{name}")
+    for pfile in package_files:
+        if pfile.is_file():
+            package_name = pfile.name.removesuffix(f".{name}")
+            file_map[package_name] = pfile
+
+    return file_map

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -172,12 +172,12 @@ def _build_file_map(
 
     for debian_dir in debian_dirs:
         default_file = debian_dir / name
-        if default_file.is_file():
+        if default_file.is_file() or default_file.is_symlink():
             file_map[project_name] = default_file
 
         package_files = debian_dir.glob(f"*.{name}")
         for pfile in package_files:
-            if pfile.is_file():
+            if pfile.is_file() or pfile.is_symlink():
                 package_name = pfile.name.removesuffix(f".{name}")
                 file_map[package_name] = pfile
 

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -70,12 +70,15 @@ def install_package_data(
     build_dir: Path,
     install_dirs: dict[str, Path],
 ) -> None:
-    """Install package-specific files from the debian directory.
+    """Install package-specific files from the packaging directories.
 
-    Read files named ``<package-name>.<name>`` from the ``debcraft/`` or
-    ``debian/`` directories in the source package and copy them to the
+    Read files named ``<package-name>.<name>`` from the ``debian/`` or
+    ``debcraft/`` directories in the source package and copy them to the
     destination path in the corresponding package, with the suffix
-    removed.
+    removed. A default file named ``<name>`` is also supported and is
+    treated as applying to ``project.name``. If matching files exist in
+    both directories for the same package, the file from ``debcraft/``
+    takes precedence over the one from ``debian/``.
 
     :param name: The name used as the file suffix.
     :param project: The project model.

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -106,8 +106,12 @@ def install_package_data(
         dest = install_dir / file_path
         dest.parent.mkdir(parents=True, exist_ok=True)
         # Add this to a state file to be able to properly clean installed files.
-        shutil.copy(pfile, dest)
-        dest.chmod(0o644)
+        if pfile.is_symlink():
+            dest.unlink(missing_ok=True)
+            dest.symlink_to(pfile.readlink())
+        else:
+            shutil.copy(pfile, dest)
+            dest.chmod(0o644)
         emit.progress(f"Install {name} file: {file_path}")
 
 
@@ -153,8 +157,11 @@ def install_package_control(
         dest = partition_dir / "package" / package / "debcraft_control" / name
         dest.parent.mkdir(parents=True, exist_ok=True)
         # Add this to a state file to be able to properly clean installed files.
-        shutil.copy(pfile, dest)
-        dest.chmod(0o644)
+        if pfile.is_symlink():
+            dest.symlink_to(pfile.readlink())
+        else:
+            shutil.copy(pfile, dest)
+            dest.chmod(0o644)
         emit.progress(f"Install {name} to package {package} control file")
 
 

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -84,31 +84,27 @@ def install_to_package_data(
     :param install_dirs: The map to the part install directory in
         each partition.
     """
-    for debian_dir_name in ("debcraft", "debian"):
-        file_map = _build_file_map(
-            name, project_name=project.name, debian_dir=build_dir / debian_dir_name
-        )
+    file_map = _build_file_map(
+        name,
+        project_name=project.name,
+        debian_dirs=[build_dir / "debian", build_dir / "debcraft"],
+    )
 
-        installed_file = False
-        for partition, install_dir in install_dirs.items():
-            if partition in ("default", "build"):
-                continue
+    for partition, install_dir in install_dirs.items():
+        if partition in ("default", "build"):
+            continue
 
-            package = partition.removeprefix("package/")
-            pfile = file_map.get(package)
-            if not pfile:
-                continue
+        package = partition.removeprefix("package/")
+        pfile = file_map.get(package)
+        if not pfile:
+            continue
 
-            file_path = Path(dest_dir) / package
-            dest = install_dir / file_path
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy(pfile, dest)
-            dest.chmod(0o644)
-            emit.progress(f"Install {name} file: {file_path}")
-            installed_file = True
-
-        if installed_file:
-            return
+        file_path = Path(dest_dir) / package
+        dest = install_dir / file_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(pfile, dest)
+        dest.chmod(0o644)
+        emit.progress(f"Install {name} file: {file_path}")
 
 
 def install_to_package_control(
@@ -132,43 +128,42 @@ def install_to_package_control(
     :param install_dirs: The map to the part install directory in
         each partition.
     """
-    for debian_dir_name in ("debcraft", "debian"):
-        file_map = _build_file_map(
-            name, project_name=project.name, debian_dir=build_dir / debian_dir_name
-        )
+    file_map = _build_file_map(
+        name,
+        project_name=project.name,
+        debian_dirs=[build_dir / "debian", build_dir / "debcraft"],
+    )
 
-        installed_file = False
-        for partition in install_dirs:
-            if partition in ("default", "build"):
-                continue
+    for partition in install_dirs:
+        if partition in ("default", "build"):
+            continue
 
-            package = partition.removeprefix("package/")
-            pfile = file_map.get(package)
-            if not pfile:
-                continue
+        package = partition.removeprefix("package/")
+        pfile = file_map.get(package)
+        if not pfile:
+            continue
 
-            dest = partition_dir / "package" / package / name / "control"
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy(pfile, dest)
-            dest.chmod(0o644)
-            emit.progress(f"Install {name} to package {package} control file")
-            installed_file = True
-
-        if installed_file:
-            return
+        dest = partition_dir / "package" / package / "control" / name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(pfile, dest)
+        dest.chmod(0o644)
+        emit.progress(f"Install {name} to package {package} control file")
 
 
-def _build_file_map(name: str, project_name: str, debian_dir: Path) -> dict[str, Path]:
+def _build_file_map(
+    name: str, project_name: str, debian_dirs: list[Path]
+) -> dict[str, Path]:
     file_map: dict[str, Path] = {}
 
-    default_file = debian_dir / name
-    if default_file.is_file():
-        file_map[project_name] = default_file
+    for debian_dir in debian_dirs:
+        default_file = debian_dir / name
+        if default_file.is_file():
+            file_map[project_name] = default_file
 
-    package_files = debian_dir.glob(f"*.{name}")
-    for pfile in package_files:
-        if pfile.is_file():
-            package_name = pfile.name.removesuffix(f".{name}")
-            file_map[package_name] = pfile
+        package_files = debian_dir.glob(f"*.{name}")
+        for pfile in package_files:
+            if pfile.is_file():
+                package_name = pfile.name.removesuffix(f".{name}")
+                file_map[package_name] = pfile
 
     return file_map

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -102,6 +102,7 @@ def install_package_data(
         file_path = Path(dest_dir) / package
         dest = install_dir / file_path
         dest.parent.mkdir(parents=True, exist_ok=True)
+        # Add this to a state file to be able to properly clean installed files.
         shutil.copy(pfile, dest)
         dest.chmod(0o644)
         emit.progress(f"Install {name} file: {file_path}")
@@ -145,6 +146,7 @@ def install_package_control(
 
         dest = partition_dir / "package" / package / "debcraft_control" / name
         dest.parent.mkdir(parents=True, exist_ok=True)
+        # Add this to a state file to be able to properly clean installed files.
         shutil.copy(pfile, dest)
         dest.chmod(0o644)
         emit.progress(f"Install {name} to package {package} control file")

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -73,7 +73,7 @@ def install_to_package_data(
     """Install package-specific files from the debian directory.
 
     Read files named ``<package-name>.<name>`` from the ``debcraft/`` or
-    ``debian/`` directories in the source  copy them to the specified
+    ``debian/`` directories in the source package and copy them to the
     destination path in the corresponding package, with the suffix
     removed.
 

--- a/debcraft/helpers/lintian.py
+++ b/debcraft/helpers/lintian.py
@@ -1,0 +1,53 @@
+#  This file is part of debcraft.
+#
+#  Copyright 2026 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Debcraft lintian helper."""
+
+import pathlib
+from typing import Any
+
+from debcraft import models
+
+from .helpers import Helper, install_to_package_data
+
+
+class Lintian(Helper):
+    """Debcraft lintian helper."""
+
+    def run(
+        self,
+        *,
+        project: models.Project,
+        build_dir: pathlib.Path,
+        install_dirs: dict[str, pathlib.Path],
+        **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        """Install copyright file.
+
+        :param build_dir: the directory containing the project being built.
+        :param install_dirs: mapping of partitions to install directories.
+        """
+        if not project.packages:
+            return
+
+        # Map package names to lintian files in the debian directory.
+        install_to_package_data(
+            name="lintian-overrides",
+            dest_dir=pathlib.Path("usr/share/lintian/overrides"),
+            project=project,
+            build_dir=build_dir,
+            install_dirs=install_dirs,
+        )

--- a/debcraft/helpers/lintian.py
+++ b/debcraft/helpers/lintian.py
@@ -35,7 +35,7 @@ class Lintian(Helper):
         install_dirs: dict[str, pathlib.Path],
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
-        """Install copyright file.
+        """Install lintian-overrides files.
 
         :param build_dir: the directory containing the project being built.
         :param install_dirs: mapping of partitions to install directories.

--- a/debcraft/helpers/lintian.py
+++ b/debcraft/helpers/lintian.py
@@ -43,7 +43,8 @@ class Lintian(Helper):
         if not project.packages:
             return
 
-        # Map package names to lintian files in the debian directory.
+        # Map package names to lintian files from debcraft/ or debian/,
+        # with debcraft/ taking precedence.
         install_package_data(
             name="lintian-overrides",
             dest_dir=pathlib.Path("usr/share/lintian/overrides"),

--- a/debcraft/helpers/lintian.py
+++ b/debcraft/helpers/lintian.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from debcraft import models
 
-from .helpers import Helper, install_to_package_data
+from .helpers import Helper, install_package_data
 
 
 class Lintian(Helper):
@@ -44,7 +44,7 @@ class Lintian(Helper):
             return
 
         # Map package names to lintian files in the debian directory.
-        install_to_package_data(
+        install_package_data(
             name="lintian-overrides",
             dest_dir=pathlib.Path("usr/share/lintian/overrides"),
             project=project,

--- a/debcraft/services/helper.py
+++ b/debcraft/services/helper.py
@@ -17,6 +17,7 @@
 """Debcraft base helper service."""
 
 import pathlib
+import shutil
 import tempfile
 from typing import Any, cast
 
@@ -134,13 +135,21 @@ class PackagingHelpersRunner:
                 continue
 
             package_dir = pathlib.Path(self._temp_dir.name) / package_name
-            control_dir = partition_dir / "package" / package_name / "debcraft_control"
+            control_dir = package_dir / "control"
             deb_dir = package_dir / "deb"
             state_dir = package_dir / "state"
 
             control_dir.mkdir(parents=True, exist_ok=True)
             deb_dir.mkdir(parents=True, exist_ok=True)
             state_dir.mkdir(parents=True, exist_ok=True)
+
+            partition_control_dir = (
+                partition_dir / "package" / package_name / "debcraft_control"
+            )
+            if partition_control_dir.is_dir():
+                for file in partition_control_dir.iterdir():
+                    if file.is_file():
+                        shutil.copy2(file, control_dir)
 
             state_dir_map = {
                 name: pathlib.Path(self._temp_dir.name) / name / "state"

--- a/debcraft/services/helper.py
+++ b/debcraft/services/helper.py
@@ -127,15 +127,14 @@ class PackagingHelpersRunner:
         emit.debug(f"run {helper_name} helper for all packages...")
 
         for package_name, package in project.packages.items():
+            partition_dir = self._project_info.partition_dir
             prime_dir = self._lifecycle.get_prime_dir(package_name)
             arch = _get_architecture(package, self._build_info)
             if not arch:
                 continue
 
             package_dir = pathlib.Path(self._temp_dir.name) / package_name
-            control_dir = (
-                self._project_info.partition_dir / "package" / package_name / "control"
-            )
+            control_dir = partition_dir / "package" / package_name / "debcraft_control"
             deb_dir = package_dir / "deb"
             state_dir = package_dir / "state"
 

--- a/debcraft/services/helper.py
+++ b/debcraft/services/helper.py
@@ -22,7 +22,7 @@ from typing import Any, cast
 
 from craft_application import AppService
 from craft_cli import emit
-from craft_parts import StepInfo
+from craft_parts import ProjectInfo, StepInfo
 from craft_platforms import BuildInfo
 from typing_extensions import Self
 
@@ -37,11 +37,13 @@ class InstallHelpersRunner:
     def __init__(
         self,
         project: models.Project,
+        project_info: ProjectInfo,
         build_info: BuildInfo,
         step_info: StepInfo,
         lifecycle: Lifecycle,
     ) -> None:
         self._project = project
+        self._project_info = project_info
         self._build_info = build_info
         self._step_info = step_info
         self._lifecycle = lifecycle
@@ -70,6 +72,7 @@ class InstallHelpersRunner:
             "step_info": self._step_info,
             "part_name": self._step_info.part_name,
             "project": project,
+            "project_info": self._project_info,
             "build_dir": self._step_info.part_build_dir,
             "install_dir": self._step_info.part_install_dir,
             "install_dirs": self._step_info.part_install_dirs,
@@ -93,10 +96,12 @@ class PackagingHelpersRunner:
     def __init__(
         self,
         project: models.Project,
+        project_info: ProjectInfo,
         build_info: BuildInfo,
         lifecycle: Lifecycle,
     ) -> None:
         self._project = project
+        self._project_info = project_info
         self._build_info = build_info
         self._lifecycle = lifecycle
         self._temp_dir = tempfile.TemporaryDirectory()
@@ -128,7 +133,9 @@ class PackagingHelpersRunner:
                 continue
 
             package_dir = pathlib.Path(self._temp_dir.name) / package_name
-            control_dir = package_dir / "control"
+            control_dir = (
+                self._project_info.partition_dir / "package" / package_name / "control"
+            )
             deb_dir = package_dir / "deb"
             state_dir = package_dir / "state"
 
@@ -167,16 +174,20 @@ class HelperService(AppService):
     def install_helpers(self, step_info: StepInfo) -> InstallHelpersRunner:
         """Obtain a runner for install helpers."""
         project = cast(models.Project, self._services.get("project").get())
+        project_info = self._services.get("lifecycle").project_info
         build_info = self._services.get("build_plan").plan()[0]
         lifecycle = cast(Lifecycle, self._services.lifecycle)
-        return InstallHelpersRunner(project, build_info, step_info, lifecycle)
+        return InstallHelpersRunner(
+            project, project_info, build_info, step_info, lifecycle
+        )
 
     def packaging_helpers(self) -> PackagingHelpersRunner:
         """Obtain a runner for packaging helpers."""
         project = cast(models.Project, self._services.get("project").get())
+        project_info = self._services.get("lifecycle").project_info
         build_info = self._services.get("build_plan").plan()[0]
         lifecycle = cast(Lifecycle, self._services.lifecycle)
-        return PackagingHelpersRunner(project, build_info, lifecycle)
+        return PackagingHelpersRunner(project, project_info, build_info, lifecycle)
 
 
 def _get_architecture(package: models.Package, build_info: BuildInfo) -> str | None:

--- a/debcraft/services/lifecycle.py
+++ b/debcraft/services/lifecycle.py
@@ -98,6 +98,7 @@ class Lifecycle(LifecycleService):
         helper_service = cast("HelperService", self._services.helper)
 
         with helper_service.install_helpers(step_info) as helper:
+            helper.run("lintian")
             helper.run("installdocs")
             helper.run("installchangelogs")
             helper.run("strip")

--- a/tests/unit/helpers/test_helpers.py
+++ b/tests/unit/helpers/test_helpers.py
@@ -74,46 +74,47 @@ def test_build_file_map(tmp_path, files, expected):
 
 
 @pytest.mark.parametrize(
-    ("source_files", "package", "expected_content"),
+    ("source_files", "packages_expected"),
     [
         pytest.param(
             {"debcraft/docs": "content"},
-            "fake-project",
-            "content",
+            {"fake-project": "content"},
             id="debcraft-default",
         ),
         pytest.param(
             {"debian/docs": "content"},
-            "fake-project",
-            "content",
+            {"fake-project": "content"},
             id="debian-default",
         ),
         pytest.param(
             {"debcraft/package-1.docs": "content"},
-            "package-1",
-            "content",
+            {"package-1": "content"},
             id="debcraft-package",
         ),
         pytest.param(
             {"debian/package-1.docs": "content"},
-            "package-1",
-            "content",
+            {"package-1": "content"},
             id="debian-package",
         ),
         pytest.param(
             {"debcraft/docs": "debcraft content", "debian/docs": "debian content"},
-            "fake-project",
-            "debcraft content",
+            {"fake-project": "debcraft content"},
             id="debcraft-priority",
+        ),
+        pytest.param(
+            {
+                "debcraft/package-1.docs": "debcraft content",
+                "debian/package-2.docs": "debian content",
+            },
+            {"package-1": "debcraft content", "package-2": "debian content"},
+            id="mixed-per-package-directories",
         ),
     ],
 )
 def test_install_package_data(
-    tmp_path, default_project, source_files, package, expected_content
+    tmp_path, default_project, source_files, packages_expected
 ):
     build_dir = tmp_path / "build"
-    install_dir = tmp_path / "install"
-    install_dir.mkdir(parents=True)
     dest_dir = Path("usr/share/doc")
 
     for rel_path, content in source_files.items():
@@ -121,7 +122,11 @@ def test_install_package_data(
         source_file.parent.mkdir(parents=True, exist_ok=True)
         source_file.write_text(content)
 
-    install_dirs = {f"package/{package}": install_dir}
+    install_dirs = {}
+    for package in packages_expected:
+        install_dir = tmp_path / package
+        install_dir.mkdir(parents=True, exist_ok=True)
+        install_dirs[f"package/{package}"] = install_dir
 
     helpers.install_package_data(
         name="docs",
@@ -131,10 +136,11 @@ def test_install_package_data(
         install_dirs=install_dirs,
     )
 
-    expected = install_dir / dest_dir / package
-    assert expected.exists()
-    assert expected.read_text() == expected_content
-    assert oct(expected.stat().st_mode)[-3:] == "644"
+    for package, expected_content in packages_expected.items():
+        expected = install_dirs[f"package/{package}"] / dest_dir / package
+        assert expected.exists()
+        assert expected.read_text() == expected_content
+        assert oct(expected.stat().st_mode)[-3:] == "644"
 
 
 @pytest.mark.parametrize(
@@ -182,30 +188,26 @@ def test_install_package_data_nothing_installed(
 
 
 @pytest.mark.parametrize(
-    ("source_files", "package", "expected_content"),
+    ("source_files", "packages_expected"),
     [
         pytest.param(
             {"debcraft/triggers": "content"},
-            "fake-project",
-            "content",
+            {"fake-project": "content"},
             id="debcraft-default",
         ),
         pytest.param(
             {"debian/triggers": "content"},
-            "fake-project",
-            "content",
+            {"fake-project": "content"},
             id="debian-default",
         ),
         pytest.param(
             {"debcraft/package-1.triggers": "content"},
-            "package-1",
-            "content",
+            {"package-1": "content"},
             id="debcraft-package",
         ),
         pytest.param(
             {"debian/package-1.triggers": "content"},
-            "package-1",
-            "content",
+            {"package-1": "content"},
             id="debian-package",
         ),
         pytest.param(
@@ -213,26 +215,33 @@ def test_install_package_data_nothing_installed(
                 "debcraft/triggers": "debcraft content",
                 "debian/triggers": "debian content",
             },
-            "fake-project",
-            "debcraft content",
+            {"fake-project": "debcraft content"},
             id="debcraft-priority",
+        ),
+        pytest.param(
+            {
+                "debcraft/package-1.triggers": "debcraft content",
+                "debian/package-2.triggers": "debian content",
+            },
+            {"package-1": "debcraft content", "package-2": "debian content"},
+            id="mixed-per-package-directories",
         ),
     ],
 )
 def test_install_package_control(
-    tmp_path, default_project, source_files, package, expected_content
+    tmp_path, default_project, source_files, packages_expected
 ):
     build_dir = tmp_path / "build"
     partition_dir = tmp_path / "partitions"
-    install_dir = tmp_path / "install"
-    install_dir.mkdir(parents=True)
 
     for rel_path, content in source_files.items():
         source_file = build_dir / rel_path
         source_file.parent.mkdir(parents=True, exist_ok=True)
         source_file.write_text(content)
 
-    install_dirs = {f"package/{package}": install_dir}
+    install_dirs = {
+        f"package/{package}": tmp_path / package for package in packages_expected
+    }
 
     helpers.install_package_control(
         name="triggers",
@@ -242,10 +251,11 @@ def test_install_package_control(
         install_dirs=install_dirs,
     )
 
-    expected = partition_dir / "package" / package / "debcraft_control" / "triggers"
-    assert expected.exists()
-    assert expected.read_text() == expected_content
-    assert oct(expected.stat().st_mode)[-3:] == "644"
+    for package, expected_content in packages_expected.items():
+        expected = partition_dir / "package" / package / "debcraft_control" / "triggers"
+        assert expected.exists()
+        assert expected.read_text() == expected_content
+        assert oct(expected.stat().st_mode)[-3:] == "644"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/helpers/test_helpers.py
+++ b/tests/unit/helpers/test_helpers.py
@@ -74,31 +74,41 @@ def test_build_file_map(tmp_path, files, expected):
 
 
 @pytest.mark.parametrize(
-    ("source_files", "packages_expected"),
+    ("source_files", "source_symlinks", "packages_expected", "preexisting_dest"),
     [
         pytest.param(
             {"debcraft/docs": "content"},
+            {},
             {"fake-project": "content"},
+            False,
             id="debcraft-default",
         ),
         pytest.param(
             {"debian/docs": "content"},
+            {},
             {"fake-project": "content"},
+            False,
             id="debian-default",
         ),
         pytest.param(
             {"debcraft/package-1.docs": "content"},
+            {},
             {"package-1": "content"},
+            False,
             id="debcraft-package",
         ),
         pytest.param(
             {"debian/package-1.docs": "content"},
+            {},
             {"package-1": "content"},
+            False,
             id="debian-package",
         ),
         pytest.param(
             {"debcraft/docs": "debcraft content", "debian/docs": "debian content"},
+            {},
             {"fake-project": "debcraft content"},
+            False,
             id="debcraft-priority",
         ),
         pytest.param(
@@ -106,13 +116,34 @@ def test_build_file_map(tmp_path, files, expected):
                 "debcraft/package-1.docs": "debcraft content",
                 "debian/package-2.docs": "debian content",
             },
+            {},
             {"package-1": "debcraft content", "package-2": "debian content"},
+            False,
             id="mixed-per-package-directories",
+        ),
+        pytest.param(
+            {},
+            {"debcraft/docs": "target"},
+            {"fake-project": Path("target")},
+            False,
+            id="symlink-source",
+        ),
+        pytest.param(
+            {},
+            {"debcraft/docs": "target"},
+            {"fake-project": Path("target")},
+            True,
+            id="symlink-source-existing-dest",
         ),
     ],
 )
 def test_install_package_data(
-    tmp_path, default_project, source_files, packages_expected
+    tmp_path,
+    default_project,
+    source_files,
+    source_symlinks,
+    packages_expected,
+    preexisting_dest,
 ):
     build_dir = tmp_path / "build"
     dest_dir = Path("usr/share/doc")
@@ -122,11 +153,22 @@ def test_install_package_data(
         source_file.parent.mkdir(parents=True, exist_ok=True)
         source_file.write_text(content)
 
+    for rel_path, target in source_symlinks.items():
+        source_link = build_dir / rel_path
+        source_link.parent.mkdir(parents=True, exist_ok=True)
+        source_link.symlink_to(target)
+
     install_dirs = {}
     for package in packages_expected:
         install_dir = tmp_path / package
         install_dir.mkdir(parents=True, exist_ok=True)
         install_dirs[f"package/{package}"] = install_dir
+
+    if preexisting_dest:
+        for package in packages_expected:
+            dest = install_dirs[f"package/{package}"] / dest_dir / package
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.symlink_to("old-target")
 
     helpers.install_package_data(
         name="docs",
@@ -136,11 +178,15 @@ def test_install_package_data(
         install_dirs=install_dirs,
     )
 
-    for package, expected_content in packages_expected.items():
+    for package, expected_value in packages_expected.items():
         expected = install_dirs[f"package/{package}"] / dest_dir / package
-        assert expected.exists()
-        assert expected.read_text() == expected_content
-        assert oct(expected.stat().st_mode)[-3:] == "644"
+        if isinstance(expected_value, Path):
+            assert expected.is_symlink()
+            assert expected.readlink() == expected_value
+        else:
+            assert expected.exists()
+            assert expected.read_text() == expected_value
+            assert oct(expected.stat().st_mode)[-3:] == "644"
 
 
 @pytest.mark.parametrize(
@@ -188,25 +234,29 @@ def test_install_package_data_nothing_installed(
 
 
 @pytest.mark.parametrize(
-    ("source_files", "packages_expected"),
+    ("source_files", "source_symlinks", "packages_expected"),
     [
         pytest.param(
             {"debcraft/triggers": "content"},
+            {},
             {"fake-project": "content"},
             id="debcraft-default",
         ),
         pytest.param(
             {"debian/triggers": "content"},
+            {},
             {"fake-project": "content"},
             id="debian-default",
         ),
         pytest.param(
             {"debcraft/package-1.triggers": "content"},
+            {},
             {"package-1": "content"},
             id="debcraft-package",
         ),
         pytest.param(
             {"debian/package-1.triggers": "content"},
+            {},
             {"package-1": "content"},
             id="debian-package",
         ),
@@ -215,6 +265,7 @@ def test_install_package_data_nothing_installed(
                 "debcraft/triggers": "debcraft content",
                 "debian/triggers": "debian content",
             },
+            {},
             {"fake-project": "debcraft content"},
             id="debcraft-priority",
         ),
@@ -223,13 +274,20 @@ def test_install_package_data_nothing_installed(
                 "debcraft/package-1.triggers": "debcraft content",
                 "debian/package-2.triggers": "debian content",
             },
+            {},
             {"package-1": "debcraft content", "package-2": "debian content"},
             id="mixed-per-package-directories",
+        ),
+        pytest.param(
+            {},
+            {"debcraft/triggers": "target"},
+            {"fake-project": Path("target")},
+            id="symlink-source",
         ),
     ],
 )
 def test_install_package_control(
-    tmp_path, default_project, source_files, packages_expected
+    tmp_path, default_project, source_files, source_symlinks, packages_expected
 ):
     build_dir = tmp_path / "build"
     partition_dir = tmp_path / "partitions"
@@ -238,6 +296,11 @@ def test_install_package_control(
         source_file = build_dir / rel_path
         source_file.parent.mkdir(parents=True, exist_ok=True)
         source_file.write_text(content)
+
+    for rel_path, target in source_symlinks.items():
+        source_link = build_dir / rel_path
+        source_link.parent.mkdir(parents=True, exist_ok=True)
+        source_link.symlink_to(target)
 
     install_dirs = {
         f"package/{package}": tmp_path / package for package in packages_expected
@@ -251,11 +314,15 @@ def test_install_package_control(
         install_dirs=install_dirs,
     )
 
-    for package, expected_content in packages_expected.items():
+    for package, expected_value in packages_expected.items():
         expected = partition_dir / "package" / package / "debcraft_control" / "triggers"
-        assert expected.exists()
-        assert expected.read_text() == expected_content
-        assert oct(expected.stat().st_mode)[-3:] == "644"
+        if isinstance(expected_value, Path):
+            assert expected.is_symlink()
+            assert expected.readlink() == expected_value
+        else:
+            assert expected.exists()
+            assert expected.read_text() == expected_value
+            assert oct(expected.stat().st_mode)[-3:] == "644"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/helpers/test_helpers.py
+++ b/tests/unit/helpers/test_helpers.py
@@ -16,6 +16,8 @@
 
 """Tests for debcraft's helpers subsystem."""
 
+from pathlib import Path
+
 import pytest
 from debcraft.helpers import helpers
 
@@ -40,3 +42,250 @@ def test_get_helper_error():
     group = MyGroup()
     with pytest.raises(ValueError, match="helper .* is not registered"):
         group.get_helper("does-not-exist")
+
+
+@pytest.mark.parametrize(
+    ("files", "expected"),
+    [
+        pytest.param(None, {}, id="missing-dir"),
+        pytest.param([], {}, id="empty-dir"),
+        pytest.param(["docs"], {"myproject": "docs"}, id="default-file"),
+        pytest.param(["pkg1.docs"], {"pkg1": "pkg1.docs"}, id="package-file"),
+        pytest.param(
+            ["docs", "pkg1.docs"],
+            {"myproject": "docs", "pkg1": "pkg1.docs"},
+            id="default-and-package-file",
+        ),
+        pytest.param(
+            ["pkg1.docs", "pkg2.docs"],
+            {"pkg1": "pkg1.docs", "pkg2": "pkg2.docs"},
+            id="multiple-package-files",
+        ),
+    ],
+)
+def test_build_file_map(tmp_path, files, expected):
+    debian_dir = tmp_path / "debian"
+    if files is not None:
+        debian_dir.mkdir()
+        for filename in files:
+            (debian_dir / filename).write_text("content")
+    result = helpers._build_file_map("docs", "myproject", debian_dir)
+    assert result == {k: debian_dir / v for k, v in expected.items()}
+
+
+@pytest.mark.parametrize(
+    ("source_files", "package", "expected_content"),
+    [
+        pytest.param(
+            {"debcraft/docs": "content"},
+            "fake-project",
+            "content",
+            id="debcraft-default",
+        ),
+        pytest.param(
+            {"debian/docs": "content"},
+            "fake-project",
+            "content",
+            id="debian-default",
+        ),
+        pytest.param(
+            {"debcraft/package-1.docs": "content"},
+            "package-1",
+            "content",
+            id="debcraft-package",
+        ),
+        pytest.param(
+            {"debian/package-1.docs": "content"},
+            "package-1",
+            "content",
+            id="debian-package",
+        ),
+        pytest.param(
+            {"debcraft/docs": "debcraft content", "debian/docs": "debian content"},
+            "fake-project",
+            "debcraft content",
+            id="debcraft-priority",
+        ),
+    ],
+)
+def test_install_to_package_data(
+    tmp_path, default_project, source_files, package, expected_content
+):
+    build_dir = tmp_path / "build"
+    install_dir = tmp_path / "install"
+    install_dir.mkdir(parents=True)
+    dest_dir = Path("usr/share/doc")
+
+    for rel_path, content in source_files.items():
+        source_file = build_dir / rel_path
+        source_file.parent.mkdir(parents=True, exist_ok=True)
+        source_file.write_text(content)
+
+    install_dirs = {f"package/{package}": install_dir}
+
+    helpers.install_to_package_data(
+        name="docs",
+        project=default_project,
+        dest_dir=dest_dir,
+        build_dir=build_dir,
+        install_dirs=install_dirs,
+    )
+
+    expected = install_dir / dest_dir / package
+    assert expected.exists()
+    assert expected.read_text() == expected_content
+    assert oct(expected.stat().st_mode)[-3:] == "644"
+
+
+@pytest.mark.parametrize(
+    ("install_dirs_keys", "source_files"),
+    [
+        pytest.param(
+            ["default", "build"],
+            ["debian/docs"],
+            id="skip-default-build",
+        ),
+        pytest.param(
+            ["package/fake-project"],
+            [],
+            id="no-matching-file",
+        ),
+    ],
+)
+def test_install_to_package_data_nothing_installed(
+    tmp_path, default_project, install_dirs_keys, source_files
+):
+    build_dir = tmp_path / "build"
+    dest_dir = Path("usr/share/doc")
+
+    for rel_path in source_files:
+        source_file = build_dir / rel_path
+        source_file.parent.mkdir(parents=True, exist_ok=True)
+        source_file.write_text("content")
+
+    install_dirs = {}
+    for key in install_dirs_keys:
+        install_dir = tmp_path / key.replace("/", "_")
+        install_dir.mkdir(parents=True, exist_ok=True)
+        install_dirs[key] = install_dir
+
+    helpers.install_to_package_data(
+        name="docs",
+        project=default_project,
+        dest_dir=dest_dir,
+        build_dir=build_dir,
+        install_dirs=install_dirs,
+    )
+
+    for install_dir in install_dirs.values():
+        assert not (install_dir / dest_dir).exists()
+
+
+@pytest.mark.parametrize(
+    ("source_files", "package", "expected_content"),
+    [
+        pytest.param(
+            {"debcraft/triggers": "content"},
+            "fake-project",
+            "content",
+            id="debcraft-default",
+        ),
+        pytest.param(
+            {"debian/triggers": "content"},
+            "fake-project",
+            "content",
+            id="debian-default",
+        ),
+        pytest.param(
+            {"debcraft/package-1.triggers": "content"},
+            "package-1",
+            "content",
+            id="debcraft-package",
+        ),
+        pytest.param(
+            {"debian/package-1.triggers": "content"},
+            "package-1",
+            "content",
+            id="debian-package",
+        ),
+        pytest.param(
+            {
+                "debcraft/triggers": "debcraft content",
+                "debian/triggers": "debian content",
+            },
+            "fake-project",
+            "debcraft content",
+            id="debcraft-priority",
+        ),
+    ],
+)
+def test_install_to_package_control(
+    tmp_path, default_project, source_files, package, expected_content
+):
+    build_dir = tmp_path / "build"
+    partition_dir = tmp_path / "partitions"
+    install_dir = tmp_path / "install"
+    install_dir.mkdir(parents=True)
+
+    for rel_path, content in source_files.items():
+        source_file = build_dir / rel_path
+        source_file.parent.mkdir(parents=True, exist_ok=True)
+        source_file.write_text(content)
+
+    install_dirs = {f"package/{package}": install_dir}
+
+    helpers.install_to_package_control(
+        name="triggers",
+        project=default_project,
+        build_dir=build_dir,
+        partition_dir=partition_dir,
+        install_dirs=install_dirs,
+    )
+
+    expected = partition_dir / "package" / package / "triggers" / "control"
+    assert expected.exists()
+    assert expected.read_text() == expected_content
+    assert oct(expected.stat().st_mode)[-3:] == "644"
+
+
+@pytest.mark.parametrize(
+    ("install_dirs_keys", "source_files"),
+    [
+        pytest.param(
+            ["default", "build"],
+            ["debian/triggers"],
+            id="skip-default-build",
+        ),
+        pytest.param(
+            ["package/fake-project"],
+            [],
+            id="no-matching-file",
+        ),
+    ],
+)
+def test_install_to_package_control_nothing_installed(
+    tmp_path, default_project, install_dirs_keys, source_files
+):
+    build_dir = tmp_path / "build"
+    partition_dir = tmp_path / "partitions"
+
+    for rel_path in source_files:
+        source_file = build_dir / rel_path
+        source_file.parent.mkdir(parents=True, exist_ok=True)
+        source_file.write_text("content")
+
+    install_dirs = {}
+    for key in install_dirs_keys:
+        install_dir = tmp_path / key.replace("/", "_")
+        install_dir.mkdir(parents=True, exist_ok=True)
+        install_dirs[key] = install_dir
+
+    helpers.install_to_package_control(
+        name="triggers",
+        project=default_project,
+        build_dir=build_dir,
+        partition_dir=partition_dir,
+        install_dirs=install_dirs,
+    )
+
+    assert not (partition_dir / "package").exists()

--- a/tests/unit/helpers/test_helpers.py
+++ b/tests/unit/helpers/test_helpers.py
@@ -69,7 +69,7 @@ def test_build_file_map(tmp_path, files, expected):
         debian_dir.mkdir()
         for filename in files:
             (debian_dir / filename).write_text("content")
-    result = helpers._build_file_map("docs", "myproject", debian_dir)
+    result = helpers._build_file_map("docs", "myproject", [debian_dir])
     assert result == {k: debian_dir / v for k, v in expected.items()}
 
 
@@ -242,7 +242,7 @@ def test_install_to_package_control(
         install_dirs=install_dirs,
     )
 
-    expected = partition_dir / "package" / package / "triggers" / "control"
+    expected = partition_dir / "package" / package / "control" / "triggers"
     assert expected.exists()
     assert expected.read_text() == expected_content
     assert oct(expected.stat().st_mode)[-3:] == "644"

--- a/tests/unit/helpers/test_helpers.py
+++ b/tests/unit/helpers/test_helpers.py
@@ -108,7 +108,7 @@ def test_build_file_map(tmp_path, files, expected):
         ),
     ],
 )
-def test_install_to_package_data(
+def test_install_package_data(
     tmp_path, default_project, source_files, package, expected_content
 ):
     build_dir = tmp_path / "build"
@@ -123,7 +123,7 @@ def test_install_to_package_data(
 
     install_dirs = {f"package/{package}": install_dir}
 
-    helpers.install_to_package_data(
+    helpers.install_package_data(
         name="docs",
         project=default_project,
         dest_dir=dest_dir,
@@ -152,7 +152,7 @@ def test_install_to_package_data(
         ),
     ],
 )
-def test_install_to_package_data_nothing_installed(
+def test_install_package_data_nothing_installed(
     tmp_path, default_project, install_dirs_keys, source_files
 ):
     build_dir = tmp_path / "build"
@@ -169,7 +169,7 @@ def test_install_to_package_data_nothing_installed(
         install_dir.mkdir(parents=True, exist_ok=True)
         install_dirs[key] = install_dir
 
-    helpers.install_to_package_data(
+    helpers.install_package_data(
         name="docs",
         project=default_project,
         dest_dir=dest_dir,
@@ -219,7 +219,7 @@ def test_install_to_package_data_nothing_installed(
         ),
     ],
 )
-def test_install_to_package_control(
+def test_install_package_control(
     tmp_path, default_project, source_files, package, expected_content
 ):
     build_dir = tmp_path / "build"
@@ -234,7 +234,7 @@ def test_install_to_package_control(
 
     install_dirs = {f"package/{package}": install_dir}
 
-    helpers.install_to_package_control(
+    helpers.install_package_control(
         name="triggers",
         project=default_project,
         build_dir=build_dir,
@@ -242,7 +242,7 @@ def test_install_to_package_control(
         install_dirs=install_dirs,
     )
 
-    expected = partition_dir / "package" / package / "control" / "triggers"
+    expected = partition_dir / "package" / package / "debcraft_control" / "triggers"
     assert expected.exists()
     assert expected.read_text() == expected_content
     assert oct(expected.stat().st_mode)[-3:] == "644"
@@ -263,7 +263,7 @@ def test_install_to_package_control(
         ),
     ],
 )
-def test_install_to_package_control_nothing_installed(
+def test_install_package_control_nothing_installed(
     tmp_path, default_project, install_dirs_keys, source_files
 ):
     build_dir = tmp_path / "build"
@@ -280,7 +280,7 @@ def test_install_to_package_control_nothing_installed(
         install_dir.mkdir(parents=True, exist_ok=True)
         install_dirs[key] = install_dir
 
-    helpers.install_to_package_control(
+    helpers.install_package_control(
         name="triggers",
         project=default_project,
         build_dir=build_dir,

--- a/tests/unit/helpers/test_lintian.py
+++ b/tests/unit/helpers/test_lintian.py
@@ -27,7 +27,9 @@ from debcraft.helpers import lintian
         pytest.param(["fake-project"], ["lintian-overrides"], id="default"),
         pytest.param(["pkg1", "pkg2"], ["pkg1.lintian-overrides"], id="single"),
         pytest.param(
-            ["pkg1", "pkg2"], ["pkg1.lintian-overrides", "pkg2.lintian"], id="both"
+            ["pkg1", "pkg2"],
+            ["pkg1.lintian-overrides", "pkg2.lintian-overrides"],
+            id="both",
         ),
     ],
 )
@@ -55,7 +57,7 @@ def test_run(tmp_path, default_project, debian_dir, packages, files):
 
         for lintian_file in files:
             if lintian_file == "lintian-overrides":
-                package_from_lintian_file = "fake-project"
+                package_from_lintian_file = default_project.name
             else:
                 package_from_lintian_file = lintian_file.removesuffix(
                     ".lintian-overrides"

--- a/tests/unit/helpers/test_lintian.py
+++ b/tests/unit/helpers/test_lintian.py
@@ -1,0 +1,70 @@
+#  This file is part of debcraft.
+#
+#  Copyright 2026 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for debcraft's lintian helper."""
+
+import pytest
+from debcraft.helpers import lintian
+
+
+@pytest.mark.parametrize("debian_dir", ["debian"])
+@pytest.mark.parametrize(
+    ("packages", "files"),
+    [
+        pytest.param(["fake-project"], ["lintian-overrides"], id="default"),
+        pytest.param(["pkg1", "pkg2"], ["pkg1.lintian-overrides"], id="single"),
+        pytest.param(
+            ["pkg1", "pkg2"], ["pkg1.lintian-overrides", "pkg2.lintian"], id="both"
+        ),
+    ],
+)
+def test_run(tmp_path, default_project, debian_dir, packages, files):
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+
+    install_dirs = {}
+    for package in packages:
+        partition = f"package/{package}"
+        install_dirs[partition] = tmp_path / package / "install"
+        install_dirs[partition].mkdir(parents=True, exist_ok=True)
+
+    for file in files:
+        file_path = build_dir / debian_dir / file
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text("content")
+
+    helper = lintian.Lintian()
+    helper.run(build_dir=build_dir, install_dirs=install_dirs, project=default_project)
+
+    for package in packages:
+        partition = f"package/{package}"
+        lintian_dir = install_dirs[partition] / "usr/share/lintian/overrides"
+
+        for lintian_file in files:
+            if lintian_file == "lintian-overrides":
+                package_from_lintian_file = "fake-project"
+            else:
+                package_from_lintian_file = lintian_file.removesuffix(
+                    ".lintian-overrides"
+                )
+
+            installed_lintian_file = lintian_dir / package_from_lintian_file
+
+            if package == package_from_lintian_file:
+                assert installed_lintian_file.exists()
+                assert installed_lintian_file.read_bytes() == b"content"
+            else:
+                assert not installed_lintian_file.exists()

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -94,11 +94,15 @@ def test_packaging_helpers_runner(
         with pytest.raises(ValueError, match="is not registered"):
             runner.run("other")
 
+    control_dir = (
+        project_info.partition_dir / "package/package-1" / "debcraft_control",
+    )
+
     assert mock_run.mock_calls == [
         call(
             prime_dir=tmp_path,
             arch="arm64",
-            control_dir=project_info.partition_dir / "package/package-1" / "control",
+            control_dir=control_dir,
             state_dir=runner_tmp_path / "package-1" / "state",
             deb_dir=runner_tmp_path / "package-1" / "deb",
             project=default_project,

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -94,15 +94,11 @@ def test_packaging_helpers_runner(
         with pytest.raises(ValueError, match="is not registered"):
             runner.run("other")
 
-    control_dir = (
-        project_info.partition_dir / "package/package-1" / "debcraft_control",
-    )
-
     assert mock_run.mock_calls == [
         call(
             prime_dir=tmp_path,
             arch="arm64",
-            control_dir=control_dir,
+            control_dir=runner_tmp_path / "package-1" / "control",
             state_dir=runner_tmp_path / "package-1" / "state",
             deb_dir=runner_tmp_path / "package-1" / "deb",
             project=default_project,

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -20,13 +20,21 @@ from unittest.mock import call
 
 import craft_platforms
 import pytest
+from craft_parts import ProjectInfo
 from debcraft import models
 from debcraft.helpers import md5sums, strip
 from debcraft.services import helper
 
 
+@pytest.fixture
+def project_info(tmp_path) -> ProjectInfo:
+    return ProjectInfo(
+        application_name="test", cache_dir=tmp_path, partitions=["partition"]
+    )
+
+
 def test_install_helpers_runner(
-    mocker, tmp_path, default_project, project_service, build_plan_service
+    mocker, tmp_path, default_project, project_info, project_service, build_plan_service
 ):
     mock_run = mocker.patch.object(strip.Strip, "run")
     lifecycle = mocker.MagicMock()
@@ -41,6 +49,7 @@ def test_install_helpers_runner(
 
     my_runner = helper.InstallHelpersRunner(
         project=default_project,
+        project_info=project_info,
         build_info=build_plan_service.plan()[0],
         step_info=step_info,
         lifecycle=lifecycle,
@@ -57,6 +66,7 @@ def test_install_helpers_runner(
             install_dir="install-dir",
             install_dirs={"partition": "install-dir"},
             project=default_project,
+            project_info=project_info,
             part_name="my-part",
             is_native=False,
             arg="foo",
@@ -65,7 +75,7 @@ def test_install_helpers_runner(
 
 
 def test_packaging_helpers_runner(
-    mocker, tmp_path, default_project, project_service, build_plan_service
+    mocker, tmp_path, default_project, project_info, project_service, build_plan_service
 ):
     mock_run = mocker.patch.object(md5sums.Md5sums, "run")
     mocker.patch("debcraft.services.helper._get_architecture", return_value="arm64")
@@ -74,6 +84,7 @@ def test_packaging_helpers_runner(
 
     my_runner = helper.PackagingHelpersRunner(
         project=default_project,
+        project_info=project_info,
         build_info=build_plan_service.plan()[0],
         lifecycle=lifecycle,
     )
@@ -87,7 +98,7 @@ def test_packaging_helpers_runner(
         call(
             prime_dir=tmp_path,
             arch="arm64",
-            control_dir=runner_tmp_path / "package-1" / "control",
+            control_dir=project_info.partition_dir / "package/package-1" / "control",
             state_dir=runner_tmp_path / "package-1" / "state",
             deb_dir=runner_tmp_path / "package-1" / "deb",
             project=default_project,

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -109,6 +109,33 @@ def test_packaging_helpers_runner(
     ]
 
 
+def test_install_helpers_control_files(
+    mocker, tmp_path, default_project, project_info, project_service, build_plan_service
+):
+    mocker.patch.object(md5sums.Md5sums, "run")
+    mocker.patch("debcraft.services.helper._get_architecture", return_value="arm64")
+    lifecycle = mocker.MagicMock()
+    lifecycle.get_prime_dir.return_value = tmp_path
+
+    partition_control_dir = (
+        project_info.partition_dir / "package" / "package-1" / "debcraft_control"
+    )
+    partition_control_dir.mkdir(parents=True, exist_ok=True)
+    (partition_control_dir / "triggers").write_text("trigger content")
+
+    my_runner = helper.PackagingHelpersRunner(
+        project=default_project,
+        project_info=project_info,
+        build_info=build_plan_service.plan()[0],
+        lifecycle=lifecycle,
+    )
+    with my_runner as runner:
+        runner.run("md5sums")
+        control_dir = pathlib.Path(runner._temp_dir.name) / "package-1" / "control"
+        assert (control_dir / "triggers").exists()
+        assert (control_dir / "triggers").read_text() == "trigger content"
+
+
 @pytest.mark.parametrize(
     ("source_archs", "binary_arch"),
     [


### PR DESCRIPTION
Add utility functions to handle the installation of package-specific files from
`debcraft/` or `debian/` to the package data or control, and use the data utility
to install lintian-overrides files.

The staging location for control files was changed to allow install helpers to
add files to the package control tarball.

Fixes #144

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
