### PR TITLE
feat: add installdebconf helper

### DIFF
--- a/debcraft/helpers/__init__.py
+++ b/debcraft/helpers/__init__.py
@@ -21,6 +21,7 @@ from .fixperms import Fixperms
 from .gencontrol import Gencontrol
 from .helpers import HelperGroup
 from .installchangelogs import Installchangelogs
+from .installdebconf import Installdebconf
 from .installdocs import Installdocs
 from .lintian import Lintian
 from .makedeb import Makedeb
@@ -36,6 +37,7 @@ class InstallHelpers(HelperGroup):
     def _register(self) -> None:
         self._register_helper("lintian", Lintian)
         self._register_helper("installdocs", Installdocs)
+        self._register_helper("installdebconf", Installdebconf)
         self._register_helper("installchangelogs", Installchangelogs)
         self._register_helper("strip", Strip)
 

--- a/debcraft/helpers/installdebconf.py
+++ b/debcraft/helpers/installdebconf.py
@@ -1,0 +1,63 @@
+#  This file is part of debcraft.
+#
+#  Copyright 2026 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Debcraft installdebconf helper."""
+
+import pathlib
+from typing import Any
+
+from debcraft import models
+
+from .helpers import Helper, install_package_control
+
+
+class Installdebconf(Helper):
+    """Debcraft installdebconf helper."""
+
+    def run(
+        self,
+        *,
+        project: models.Project,
+        build_dir: pathlib.Path,
+        partition_dir: pathlib.Path,
+        install_dirs: dict[str, pathlib.Path],
+        **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        """Install debconf files.
+
+        :param project: the project model.
+        :param build_dir: the directory containing the project being built.
+        :param partition_dir: the work directory for partition data.
+        :param install_dirs: mapping of partitions to install directories.
+        """
+        if not project.packages:
+            return
+
+        install_package_control(
+            name="config",
+            project=project,
+            build_dir=build_dir,
+            partition_dir=partition_dir,
+            install_dirs=install_dirs,
+        )
+
+        install_package_control(
+            name="templates",
+            project=project,
+            build_dir=build_dir,
+            partition_dir=partition_dir,
+            install_dirs=install_dirs,
+        )

--- a/debcraft/services/helper.py
+++ b/debcraft/services/helper.py
@@ -78,6 +78,7 @@ class InstallHelpersRunner:
             "install_dir": self._step_info.part_install_dir,
             "install_dirs": self._step_info.part_install_dirs,
             "is_native": self._step_info.is_native,
+            "partition_dir": self._project_info.partition_dir,
         }
         common_kwargs |= kwargs
 

--- a/debcraft/services/lifecycle.py
+++ b/debcraft/services/lifecycle.py
@@ -101,6 +101,7 @@ class Lifecycle(LifecycleService):
             helper.run("lintian")
             helper.run("installdocs")
             helper.run("installchangelogs")
+            helper.run("installdebconf")
             helper.run("strip")
 
         return True

--- a/tests/unit/helpers/test_installdebconf.py
+++ b/tests/unit/helpers/test_installdebconf.py
@@ -1,0 +1,83 @@
+#  This file is part of debcraft.
+#
+#  Copyright 2026 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for debcraft's installdebconf helper."""
+
+import pytest
+from debcraft.helpers import installdebconf
+
+
+@pytest.mark.parametrize("debian_dir", ["debian"])
+@pytest.mark.parametrize(
+    ("packages", "files"),
+    [
+        pytest.param(["fake-project"], ["config", "templates"], id="default"),
+        pytest.param(["pkg1", "pkg2"], ["pkg1.config", "pkg1.templates"], id="single"),
+        pytest.param(
+            ["pkg1", "pkg2"],
+            ["pkg1.config", "pkg1.templates", "pkg2.config", "pkg2.templates"],
+            id="both",
+        ),
+    ],
+)
+def test_run(tmp_path, default_project, debian_dir, packages, files):
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+
+    install_dirs = {}
+    for package in packages:
+        partition = f"package/{package}"
+        install_dirs[partition] = tmp_path / package / "install"
+        install_dirs[partition].mkdir(parents=True, exist_ok=True)
+
+    for file in files:
+        file_path = build_dir / debian_dir / file
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text("content")
+
+    helper = installdebconf.Installdebconf()
+    helper.run(
+        build_dir=build_dir,
+        partition_dir=tmp_path,
+        project=default_project,
+        install_dirs=install_dirs,
+    )
+
+    for package in packages:
+        partition = f"package/{package}"
+        conf_dir = tmp_path / partition
+
+        file_types_for_package: set[str] = set()
+        all_file_types: set[str] = set()
+
+        for conf_file in files:
+            if "." not in conf_file:
+                file_package = default_project.name
+                file_type = conf_file  # "config" or "templates"
+            else:
+                file_package, _, file_type = conf_file.partition(".")
+
+            all_file_types.add(file_type)
+            if package == file_package:
+                file_types_for_package.add(file_type)
+
+        for file_type in all_file_types:
+            installed_conf_file = conf_dir / "debcraft_control" / file_type
+            if file_type in file_types_for_package:
+                assert installed_conf_file.exists()
+                assert installed_conf_file.read_bytes() == b"content"
+            else:
+                assert not installed_conf_file.exists()

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -69,6 +69,7 @@ def test_install_helpers_runner(
             project_info=project_info,
             part_name="my-part",
             is_native=False,
+            partition_dir=project_info.partition_dir,
             arg="foo",
         )
     ]


### PR DESCRIPTION
Install debconf config and templates files from `debcraft/` or `debian/`
to the package control directory.

Missing features to be addressed in separate PRs:
* `#DEBHELPER#` token replacement in config scripts
* postrm debconf cleanup generation
* debian/po/ translation merging via po2debconf
* Token substitution (`#DEB_HOST_NAME#`, `#ENV.NAME#`, `#PACKAGE#`, -D/--define)

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---
