### PR TITLE
ci: add path filter to qa workflow, make jobs conditional

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -15,6 +15,10 @@ jobs:
     outputs:
       source-files: ${{ steps.filter.outputs.source-files }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -27,12 +27,12 @@ jobs:
     uses: canonical/starflow/.github/workflows/lint-python.yaml@main
     needs: filter
     with:
-      source-files: ${{ needs.filter.output.source-files }}
+      source-files: ${{ needs.filter.outputs.source-files }}
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     needs: filter
     with:
-      source-files: ${{ needs.filter.output.source-files }}
+      source-files: ${{ needs.filter.outputs.source-files }}
       # Disable 3.11 and 3.13 tests while wheels for python-apt and
       # pygit2 are not fully available.
       fast-test-platforms: '["ubuntu-22.04", "ubuntu-22.04-arm", "ubuntu-24.04", "ubuntu-24.04-arm"]'

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -10,11 +10,29 @@ on:
   pull_request:
 
 jobs:
+  filter:
+    runs-on: ubuntu-slim
+    outputs:
+      source-files: ${{ steps.filter.outputs.source-files }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          # Combine multiple negation checks into a union (¬A ∧ ¬B ∧ ¬C), because individual entries are checked independently (A ∨ B ∨ C).
+          # If we ever need to filter only for docs, glob 'docs/**/*' and '**/*.md'
+          filters: |
+            source-files:
+              - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
   lint:
     uses: canonical/starflow/.github/workflows/lint-python.yaml@main
+    needs: filter
+    with:
+      source-files: ${{ needs.filter.output.source-files }}
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    needs: filter
     with:
+      source-files: ${{ needs.filter.output.source-files }}
       # Disable 3.11 and 3.13 tests while wheels for python-apt and
       # pygit2 are not fully available.
       fast-test-platforms: '["ubuntu-22.04", "ubuntu-22.04-arm", "ubuntu-24.04", "ubuntu-24.04-arm"]'


### PR DESCRIPTION
Add the filter to the workflow directly, and pass it on to the Starflow lint and test workflows.

Depends on https://github.com/canonical/starflow/pull/143. The lint workflow has already been changed upstream.

For CRAFT-5161.

---

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
