### PR TITLE
feat(installdebconf): token substitution

### DIFF
--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -182,7 +182,7 @@ def install_package_control(
                 mapping |= templater.get_dynamic_values()
                 # Common substitution that can vary by the package being built
                 mapping["PACKAGE"] = package
-                contents = _DebianTemplater(contents).substitute(mapping)
+                contents = _DebianTemplater(contents).safe_substitute(mapping)
                 dest.write_text(contents)
 
             dest.chmod(0o644)

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -16,9 +16,12 @@
 
 """Debcraft helpers base."""
 
+import os
+import re
 import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
+from string import Template
 
 from craft_cli import emit
 
@@ -122,6 +125,7 @@ def install_package_control(
     build_dir: Path,
     partition_dir: Path,
     install_dirs: dict[str, Path],
+    template_mapping: dict[str, str] | None = None,
 ) -> None:
     """Install package-specific files from the debian directory.
 
@@ -138,6 +142,10 @@ def install_package_control(
     :param partition_dir: The path to the project partitions.
     :param install_dirs: The map to the part install directory in
         each partition.
+    :param template_mapping: A mapping of strings to substitute into the file.
+        If set to None, no substitutions are performed. If set to any dict,
+        even an empty one, special template keys such as "ENV." will be filled
+        in anyways.
     """
     file_map = _build_file_map(
         name,
@@ -160,8 +168,18 @@ def install_package_control(
         if pfile.is_symlink():
             dest.symlink_to(pfile.readlink())
         else:
-            shutil.copy(pfile, dest)
+            if template_mapping is None:
+                shutil.copy(pfile, dest)
+            else:
+                contents = pfile.read_text()
+                template_mapping |= _DebianTemplater.get_dynamic_values(contents)
+                # Common substitution that can vary by the package being built
+                template_mapping["PACKAGE"] = package
+                contents = _DebianTemplater(contents).substitute(template_mapping)
+                dest.write_text(contents)
+
             dest.chmod(0o644)
+
         emit.progress(f"Install {name} to package {package} control file")
 
 
@@ -182,3 +200,50 @@ def _build_file_map(
                 file_map[package_name] = pfile
 
     return file_map
+
+
+_VALID_CONFIG_TEMPLATE_REGEX = "[A-Za-z0-9_.+]+"
+
+
+class _DebianTemplater(Template):
+    """A templating structure to fill in token templates in debian config files."""
+
+    # https://docs.python.org/3/library/string.html#template-strings-strings
+    #
+    # \#                                                     The first character to look for to begin replacement
+    #   (?:                                                  Non-capturing group that must come after the #
+    #     (?<escaped>\#)                              |      What it looks like when the user wants to escape the
+    #                                                 |      template sequence. In this case, ## becomes a literal
+    #                                                 |      '#' in the final output.
+    #     (?P<named>{_VALID_CONFIG_TEMPLATE_REGEX})   |      Match a valid key that would go between #'s.
+    #                                              \# |      Enforce a closing '#' for the template string.
+    #     (?P<braced>(?!))                            |      Unused, never matches
+    #     (?P<invalid>{_VALID_CONFIG_TEMPLATE_REGEX}(?!\#))  What an invalid match looks like -- in this case, an
+    #                                                        identifier that isn't terminated by a '#'.
+    #   )                                                    End
+    pattern = rf"""
+        \#(?:
+            (?P<escaped>\#)                             |
+            (?P<named>{_VALID_CONFIG_TEMPLATE_REGEX})\# |
+            (?P<braced>(?!))                            |
+            (?P<invalid>{_VALID_CONFIG_TEMPLATE_REGEX}(?!\#))
+        )
+    """
+    delimiter = "#"
+
+    @classmethod
+    def get_dynamic_values(cls, contents: str) -> dict[str, str]:
+        mapping = {}
+
+        for needle in re.finditer(cls.pattern, contents):
+            key = needle.group("named")
+            if not key:
+                continue
+
+            # Populate "ENV." values
+            if key.startswith("ENV."):
+                _, name = key.split(".", maxsplit=1)
+                # Default to an empty string to stay bashy
+                mapping[key] = os.getenv(name, "")
+
+        return mapping

--- a/debcraft/helpers/helpers.py
+++ b/debcraft/helpers/helpers.py
@@ -16,6 +16,7 @@
 
 """Debcraft helpers base."""
 
+import copy
 import os
 import re
 import shutil
@@ -166,16 +167,22 @@ def install_package_control(
         dest.parent.mkdir(parents=True, exist_ok=True)
         # Add this to a state file to be able to properly clean installed files.
         if pfile.is_symlink():
+            # Substitution is not performed for symlinks, as this would mean modifying
+            # source files through the link instead of modifying a copy
             dest.symlink_to(pfile.readlink())
         else:
             if template_mapping is None:
                 shutil.copy(pfile, dest)
             else:
                 contents = pfile.read_text()
-                template_mapping |= _DebianTemplater.get_dynamic_values(contents)
+                templater = _DebianTemplater(contents)
+                mapping = copy.deepcopy(template_mapping)
+                # Dynamic values can depend on the contents of the file being installed,
+                # and so must be determined here when we know what file is being read
+                mapping |= templater.get_dynamic_values()
                 # Common substitution that can vary by the package being built
-                template_mapping["PACKAGE"] = package
-                contents = _DebianTemplater(contents).substitute(template_mapping)
+                mapping["PACKAGE"] = package
+                contents = _DebianTemplater(contents).substitute(mapping)
                 dest.write_text(contents)
 
             dest.chmod(0o644)
@@ -202,7 +209,7 @@ def _build_file_map(
     return file_map
 
 
-_VALID_CONFIG_TEMPLATE_REGEX = "[A-Za-z0-9_.+]+"
+_VALID_CONFIG_TEMPLATE_REGEX = r"[A-Za-z0-9_\.+]+"
 
 
 class _DebianTemplater(Template):
@@ -213,9 +220,9 @@ class _DebianTemplater(Template):
     # \#                                                     The first character to look for to begin replacement
     #   (?:                                                  Non-capturing group that must come after the #
     #     (?<escaped>\#)                              |      What it looks like when the user wants to escape the
-    #                                                 |      template sequence. In this case, ## becomes a literal
-    #                                                 |      '#' in the final output.
-    #     (?P<named>{_VALID_CONFIG_TEMPLATE_REGEX})   |      Match a valid key that would go between #'s.
+    #                                                        template sequence. In this case, ## becomes a literal
+    #                                                        '#' in the final output.
+    #     (?P<named>{_VALID_CONFIG_TEMPLATE_REGEX})          Match a valid key that would go between #'s.
     #                                              \# |      Enforce a closing '#' for the template string.
     #     (?P<braced>(?!))                            |      Unused, never matches
     #     (?P<invalid>{_VALID_CONFIG_TEMPLATE_REGEX}(?!\#))  What an invalid match looks like -- in this case, an
@@ -231,11 +238,10 @@ class _DebianTemplater(Template):
     """
     delimiter = "#"
 
-    @classmethod
-    def get_dynamic_values(cls, contents: str) -> dict[str, str]:
+    def get_dynamic_values(self) -> dict[str, str]:
         mapping = {}
 
-        for needle in re.finditer(cls.pattern, contents):
+        for needle in re.finditer(self.pattern, self.template):
             key = needle.group("named")
             if not key:
                 continue

--- a/debcraft/helpers/installdebconf.py
+++ b/debcraft/helpers/installdebconf.py
@@ -70,4 +70,5 @@ class Installdebconf(Helper):
             build_dir=build_dir,
             partition_dir=partition_dir,
             install_dirs=install_dirs,
+            template_mapping=template_mapping,
         )

--- a/debcraft/helpers/installdebconf.py
+++ b/debcraft/helpers/installdebconf.py
@@ -19,6 +19,8 @@
 import pathlib
 from typing import Any
 
+from craft_parts import ProjectInfo
+
 from debcraft import models
 
 from .helpers import Helper, install_package_control
@@ -31,6 +33,7 @@ class Installdebconf(Helper):
         self,
         *,
         project: models.Project,
+        project_info: ProjectInfo,
         build_dir: pathlib.Path,
         partition_dir: pathlib.Path,
         install_dirs: dict[str, pathlib.Path],
@@ -46,12 +49,19 @@ class Installdebconf(Helper):
         if not project.packages:
             return
 
+        template_mapping = {
+            "DEB_HOST_NAME": project_info.arch_build_for,
+            "DEB_BUILD_NAME": project_info.arch_build_on,
+            "DEB_TARGET_NAME": project_info.arch_build_for,
+        }
+
         install_package_control(
             name="config",
             project=project,
             build_dir=build_dir,
             partition_dir=partition_dir,
             install_dirs=install_dirs,
+            template_mapping=template_mapping,
         )
 
         install_package_control(

--- a/debcraft/helpers/installdebconf.py
+++ b/debcraft/helpers/installdebconf.py
@@ -70,5 +70,4 @@ class Installdebconf(Helper):
             build_dir=build_dir,
             partition_dir=partition_dir,
             install_dirs=install_dirs,
-            template_mapping=template_mapping,
         )

--- a/tests/unit/helpers/test_helpers.py
+++ b/tests/unit/helpers/test_helpers.py
@@ -385,12 +385,18 @@ def test_install_package_control_nothing_installed(
             "#let-me-live",
             id="escape-delimiter",
         ),
+        pytest.param(
+            "#leave_me_alone#",
+            {},
+            "#leave_me_alone#",
+            id="ignore-unknown",
+        ),
     ],
 )
 def test_debian_templater(
     contents: str, mapping: dict[str, str], expected: str
 ) -> None:
-    assert _DebianTemplater(contents).substitute(mapping) == expected
+    assert _DebianTemplater(contents).safe_substitute(mapping) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/helpers/test_helpers.py
+++ b/tests/unit/helpers/test_helpers.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 from debcraft.helpers import helpers
+from debcraft.helpers.helpers import _DebianTemplater
 
 
 class MyHelper(helpers.Helper):
@@ -366,3 +367,62 @@ def test_install_package_control_nothing_installed(
     )
 
     assert not (partition_dir / "package").exists()
+
+
+@pytest.mark.parametrize(
+    ("contents", "mapping", "expected"),
+    [
+        pytest.param("#one#", {"one": "hakuna"}, "hakuna", id="simple"),
+        pytest.param(
+            "#one# #two#",
+            {"one": "hakuna", "two": "matata"},
+            "hakuna matata",
+            id="it-means-no-worries",
+        ),
+        pytest.param(
+            "##let-me-live",
+            {"let-me-live": "no"},
+            "#let-me-live",
+            id="escape-delimiter",
+        ),
+    ],
+)
+def test_debian_templater(
+    contents: str, mapping: dict[str, str], expected: str
+) -> None:
+    assert _DebianTemplater(contents).substitute(mapping) == expected
+
+
+@pytest.mark.parametrize(
+    ("env", "contents", "expected"),
+    [
+        pytest.param(
+            {"one": "hakuna"}, "#ENV.one#", {"ENV.one": "hakuna"}, id="simple"
+        ),
+        pytest.param(
+            {"one": "hakuna", "two": "matata"},
+            "#ENV.one# #ENV.two#",
+            {"ENV.one": "hakuna", "ENV.two": "matata"},
+            id="multi",
+        ),
+        pytest.param(
+            {"one": "hakuna", "two": "matata"},
+            "#ENV.one#",
+            {"ENV.one": "hakuna"},
+            id="only-specified",
+        ),
+        pytest.param({}, "#ENV.one#", {"ENV.one": ""}, id="empty"),
+    ],
+)
+def test_debian_templater_dynamic_values_env(
+    monkeypatch: pytest.MonkeyPatch,
+    env: dict[str, str],
+    contents: str,
+    expected: dict[str, str],
+) -> None:
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    result = _DebianTemplater.get_dynamic_values(contents)
+
+    assert result == expected

--- a/tests/unit/helpers/test_helpers.py
+++ b/tests/unit/helpers/test_helpers.py
@@ -423,6 +423,7 @@ def test_debian_templater_dynamic_values_env(
     for k, v in env.items():
         monkeypatch.setenv(k, v)
 
-    result = _DebianTemplater.get_dynamic_values(contents)
+    templater = _DebianTemplater(contents)
+    result = templater.get_dynamic_values()
 
     assert result == expected

--- a/tests/unit/helpers/test_installdebconf.py
+++ b/tests/unit/helpers/test_installdebconf.py
@@ -113,7 +113,7 @@ def test_run_substitutions(
         for package in packages:
             file = (build_dir / "debian" / package).with_suffix(suffix)
             file.parent.mkdir(parents=True, exist_ok=True)
-            file.write_text("#PACKAGE# #DEB_HOST_NAME# #ENV.FOO#")
+            file.write_text("#PACKAGE# #DEB_HOST_NAME# #ENV.FOO# #IGNORE_ME#")
 
     project_info = ProjectInfo(
         application_name="project",
@@ -135,10 +135,10 @@ def test_run_substitutions(
         # Do not substitute content in templates files
         conf_dir = tmp_path / "package" / package / "debcraft_control"
         template = conf_dir / "templates"
-        assert template.read_text() == "#PACKAGE# #DEB_HOST_NAME# #ENV.FOO#"
+        assert template.read_text() == "#PACKAGE# #DEB_HOST_NAME# #ENV.FOO# #IGNORE_ME#"
 
         # Substitute contents in config files
         # The environment should be read and the #PACKAGE# variable should change
         # per-package being built
         config = conf_dir / "config"
-        assert config.read_text() == f"{package} amd64 bar"
+        assert config.read_text() == f"{package} amd64 bar #IGNORE_ME#"

--- a/tests/unit/helpers/test_installdebconf.py
+++ b/tests/unit/helpers/test_installdebconf.py
@@ -17,6 +17,7 @@
 """Tests for debcraft's installdebconf helper."""
 
 import pytest
+from craft_parts import ProjectInfo
 from debcraft.helpers import installdebconf
 
 
@@ -46,7 +47,14 @@ def test_run(tmp_path, default_project, debian_dir, packages, files):
     for file in files:
         file_path = build_dir / debian_dir / file
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text("content")
+        file_path.write_text("#DEB_HOST_NAME#")
+
+    project_info = ProjectInfo(
+        application_name="project",
+        cache_dir=tmp_path / "cache",
+        arch="amd64",
+        partitions=["partition"],
+    )
 
     helper = installdebconf.Installdebconf()
     helper.run(
@@ -54,6 +62,7 @@ def test_run(tmp_path, default_project, debian_dir, packages, files):
         partition_dir=tmp_path,
         project=default_project,
         install_dirs=install_dirs,
+        project_info=project_info,
     )
 
     for package in packages:
@@ -78,6 +87,6 @@ def test_run(tmp_path, default_project, debian_dir, packages, files):
             installed_conf_file = conf_dir / "debcraft_control" / file_type
             if file_type in file_types_for_package:
                 assert installed_conf_file.exists()
-                assert installed_conf_file.read_bytes() == b"content"
+                assert installed_conf_file.read_bytes() == b"amd64"
             else:
                 assert not installed_conf_file.exists()

--- a/tests/unit/helpers/test_installdebconf.py
+++ b/tests/unit/helpers/test_installdebconf.py
@@ -16,9 +16,12 @@
 
 """Tests for debcraft's installdebconf helper."""
 
+from pathlib import Path
+
 import pytest
 from craft_parts import ProjectInfo
 from debcraft.helpers import installdebconf
+from debcraft.models import Project
 
 
 @pytest.mark.parametrize("debian_dir", ["debian"])
@@ -47,7 +50,7 @@ def test_run(tmp_path, default_project, debian_dir, packages, files):
     for file in files:
         file_path = build_dir / debian_dir / file
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text("#DEB_HOST_NAME#")
+        file_path.write_text("content")
 
     project_info = ProjectInfo(
         application_name="project",
@@ -87,6 +90,55 @@ def test_run(tmp_path, default_project, debian_dir, packages, files):
             installed_conf_file = conf_dir / "debcraft_control" / file_type
             if file_type in file_types_for_package:
                 assert installed_conf_file.exists()
-                assert installed_conf_file.read_bytes() == b"amd64"
+                assert installed_conf_file.read_bytes() == b"content"
             else:
                 assert not installed_conf_file.exists()
+
+
+def test_run_substitutions(
+    tmp_path: Path, default_project: Project, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FOO", "bar")
+    packages = ["pkg1", "pkg2"]
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+
+    install_dirs = {}
+    for package in packages:
+        partition = f"package/{package}"
+        install_dirs[partition] = tmp_path / package / "install"
+        install_dirs[partition].mkdir(parents=True, exist_ok=True)
+
+    for suffix in (".config", ".templates"):
+        for package in packages:
+            file = (build_dir / "debian" / package).with_suffix(suffix)
+            file.parent.mkdir(parents=True, exist_ok=True)
+            file.write_text("#PACKAGE# #DEB_HOST_NAME# #ENV.FOO#")
+
+    project_info = ProjectInfo(
+        application_name="project",
+        cache_dir=tmp_path / "cache",
+        arch="amd64",
+        partitions=["partition"],
+    )
+
+    helper = installdebconf.Installdebconf()
+    helper.run(
+        build_dir=build_dir,
+        partition_dir=tmp_path,
+        project=default_project,
+        install_dirs=install_dirs,
+        project_info=project_info,
+    )
+
+    for package in packages:
+        # Do not substitute content in templates files
+        conf_dir = tmp_path / "package" / package / "debcraft_control"
+        template = conf_dir / "templates"
+        assert template.read_text() == "#PACKAGE# #DEB_HOST_NAME# #ENV.FOO#"
+
+        # Substitute contents in config files
+        # The environment should be read and the #PACKAGE# variable should change
+        # per-package being built
+        config = conf_dir / "config"
+        assert config.read_text() == f"{package} amd64 bar"

--- a/tests/unit/services/test_helpers.py
+++ b/tests/unit/services/test_helpers.py
@@ -20,7 +20,7 @@ from unittest.mock import call
 
 import craft_platforms
 import pytest
-from craft_parts import ProjectInfo
+from craft_parts import ProjectDirs, ProjectInfo
 from debcraft import models
 from debcraft.helpers import md5sums, strip
 from debcraft.services import helper
@@ -28,8 +28,12 @@ from debcraft.services import helper
 
 @pytest.fixture
 def project_info(tmp_path) -> ProjectInfo:
+    dirs = ProjectDirs(partitions=["partition"], work_dir=tmp_path)
     return ProjectInfo(
-        application_name="test", cache_dir=tmp_path, partitions=["partition"]
+        application_name="test",
+        cache_dir=tmp_path / "cache",
+        partitions=["partition"],
+        project_dirs=dirs,
     )
 
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Implements token substitution for special template config files. Some notes for reviewers:

- The "ENV." prefix means that the value should be looked up from the current environment.
- It seems like `${...}` is a more common delimiter than `#...#`, but this PR only focuses on working with `dh_installdebconf`'s behaviors, which opt for `#...#` instead. This work shouldn't be terribly difficult to refactor to work with either delimiter style in the future.
- This does not implement per-package values (e.g. `pkg.foo.CUSTOM_KEY`, `pkg.bar.CUSTOM_KEY`), as those are only set via the CLI for debhelpers normally and such inputs are not yet supported.

Closes #159 
DEBCRAFT-71