### PR TITLE
fix(makeshlibs): don't always add revision to shlib versions

### DIFF
--- a/debcraft/helpers/makeshlibs.py
+++ b/debcraft/helpers/makeshlibs.py
@@ -108,7 +108,7 @@ class Makeshlibs(Helper):
         if not sep or rev.endswith("~"):
             return version
         emit.debug(
-            f"Stripping revision '-{rev}' from package version {upstream!r} for shlibs"
+            f"Stripping revision '-{rev}' from package version {version!r} for shlibs"
         )
         return upstream
 

--- a/debcraft/helpers/makeshlibs.py
+++ b/debcraft/helpers/makeshlibs.py
@@ -52,7 +52,8 @@ class Makeshlibs(Helper):
         """Create a list of shared libraries present in this package."""
         shlibs_file = control_dir / "shlibs"
         package = project.get_package(package_name)
-        version = cast(str, package.version or project.version)
+        version_raw = cast(str, package.version or project.version)
+        version = self._get_shlibs_friendly_version(version_raw)
         arch_triplet = util.get_arch_triplet()
         lib_dirs = _get_lib_dirs(arch_triplet)
 
@@ -92,6 +93,24 @@ class Makeshlibs(Helper):
         # Copy to helper state
         state_shlibs_file = state_dir / f"{package_name}:{arch}.shlibs"
         shutil.copy(shlibs_file, state_shlibs_file)
+
+    @staticmethod
+    def _get_shlibs_friendly_version(version: str) -> str:
+        """Strip any revision values from a package version.
+
+        See Debian Policy 8.6.4 for the source of this logic. But in short,
+
+        - shlib files should not contain revisions, and instead prefer the upstream version
+        - the "revision" is separated from the version by the _final_ hyphen
+        - if the version string ends with a tilde, prefer the revision despite previous points
+        """
+        upstream, sep, rev = version.rpartition("-")
+        if not sep or rev.endswith("~"):
+            return version
+        emit.debug(
+            f"Stripping revision '-{rev}' from package version {upstream!r} for shlibs"
+        )
+        return upstream
 
 
 @functools.lru_cache

--- a/tests/unit/helpers/test_makeshlibs.py
+++ b/tests/unit/helpers/test_makeshlibs.py
@@ -22,13 +22,18 @@ from debcraft.helpers import makeshlibs
 
 
 @pytest.mark.parametrize(
-    ("arch", "create_files"),
+    ("arch", "create_files", "pkg_version", "expected_version"),
     [
-        pytest.param("s390x", True, id="native-arch"),
-        pytest.param("riscv64", False, id="foreign-arch"),
+        pytest.param("s390x", True, "2.0", "2.0", id="native-arch"),
+        pytest.param("riscv64", False, "2.0", "2.0", id="foreign-arch"),
+        pytest.param(
+            "s390x", True, "2.0-1ubuntu5", "2.0", id="native-arch-with-revision"
+        ),
     ],
 )
-def test_run(mocker, tmp_path, default_project, arch, create_files):
+def test_run(
+    mocker, tmp_path, default_project, arch, create_files, pkg_version, expected_version
+):
     prime_dir = tmp_path / "prime"
     control_dir = tmp_path / "control"
     state_dir = tmp_path / "state"
@@ -45,6 +50,10 @@ def test_run(mocker, tmp_path, default_project, arch, create_files):
             )
         ],
     )
+    mocker.patch(
+        "debcraft.models.project.Project.get_package",
+        return_value=mocker.MagicMock(version=pkg_version),
+    )
 
     helper = makeshlibs.Makeshlibs()
     helper.run(
@@ -60,8 +69,34 @@ def test_run(mocker, tmp_path, default_project, arch, create_files):
     triggers_file = control_dir / "triggers"
 
     if create_files:
-        assert shlibs_file.read_text() == "libfoo 5 package-1 (>= 2.0)\n"
+        assert (
+            shlibs_file.read_text() == f"libfoo 5 package-1 (>= {expected_version})\n"
+        )
         assert triggers_file.read_text() == "activate-noawait ldconfig\n"
     else:
         assert not shlibs_file.exists()
         assert not triggers_file.exists()
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        pytest.param("1.0.0", "1.0.0", id="no-revision"),
+        pytest.param("1.0.0-1", "1.0.0", id="simple-debian-revision"),
+        pytest.param("12.0.0-1ubuntu5", "12.0.0", id="ubuntu-revision"),
+        pytest.param("2:1.0.0-1", "2:1.0.0", id="epoch-with-revision"),
+        pytest.param("2:1.0.0", "2:1.0.0", id="epoch-no-revision"),
+        pytest.param("1.0.0-1-2", "1.0.0-1", id="upstream-version-contains-hyphen"),
+        pytest.param(
+            "12.0.0-1ubuntu5~", "12.0.0-1ubuntu5~", id="revision-tilde-backport"
+        ),
+        pytest.param("12.0.0~rc1-1", "12.0.0~rc1", id="upstream-tilde-with-revision"),
+        pytest.param(
+            "12.0.0~rc1-1ubuntu5~",
+            "12.0.0~rc1-1ubuntu5~",
+            id="upstream-tilde-revision-tilde",
+        ),
+    ],
+)
+def test_get_shlibs_friendly_version(version: str, expected: str) -> None:
+    assert makeshlibs.Makeshlibs._get_shlibs_friendly_version(version) == expected


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?

---

Implements some logic from Debian Policy 8.6.4. See the docstring in the new `_get_shlibs_friendly_version` for a summary.

Fixes #150.
DEBCRAFT-76